### PR TITLE
feat: se agrega middleware para errores personalizados

### DIFF
--- a/Controllers/XmlController.cs
+++ b/Controllers/XmlController.cs
@@ -79,7 +79,7 @@ public class XmlController : ControllerBase
       ErrorResponse errorResponse = new()
       {
         Status = HttpStatusCode.BadRequest.GetHashCode(),
-        Title = "Error al procesar el xml",
+        Title = "Error al procesar el xml.",
         Detail = e.Message,
         Errors = [e.Message]
       };

--- a/Middlewares/ErrorResponseMiddleware.cs
+++ b/Middlewares/ErrorResponseMiddleware.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using Contpaqi.Entities;
+
+namespace contpaqi.Middlewares
+{
+    public static class ErrorResponseMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseErrorResponse(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<ErrorResponseMiddleware>();
+        }
+    }
+    public class ErrorResponseMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public ErrorResponseMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext httpContext)
+        {
+            var originalStatus = httpContext.Response.StatusCode;
+
+            await _next(httpContext);
+
+            //TODO: Se puede desglosar cada uno de los status :-(
+            if (httpContext.Response.StatusCode == 401)
+            {
+                httpContext.Response.ContentType = "application/json";
+                ErrorResponse errorResponse = new()
+                {
+                    Status = HttpStatusCode.Unauthorized.GetHashCode(),
+                    Title = "Unauthorized",
+                    Detail = "El token de acceso ha caducado o no es válido."
+                };
+
+                await httpContext.Response.WriteAsJsonAsync(errorResponse);
+            }
+            else if (httpContext.Response.StatusCode == 403)
+            {
+                httpContext.Response.ContentType = "application/json";
+                ErrorResponse errorResponse = new()
+                {
+                    Status = HttpStatusCode.Forbidden.GetHashCode(),
+                    Title = "Forbidden",
+                    Detail = "No tienes permiso para acceder a este recurso."
+                };
+
+                await httpContext.Response.WriteAsJsonAsync(errorResponse);
+            }
+            else if (httpContext.Response.StatusCode >= 500 && httpContext.Response.StatusCode < 600)
+            {
+                httpContext.Response.ContentType = "application/json";
+                ErrorResponse errorResponse = new()
+                {
+                    Status = HttpStatusCode.InternalServerError.GetHashCode(),
+                    Title = "Internal Server Error",
+                    Detail = "Se produjo un error inesperado. Inténtelo de nuevo más tarde."
+                };
+
+                await httpContext.Response.WriteAsJsonAsync(errorResponse);
+            }
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,4 @@
+using contpaqi.Middlewares;
 using Contpaqi.Services;
 using Microsoft.OpenApi.Models;
 
@@ -84,6 +85,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+app.UseErrorResponse();
 app.UseRouting();
 app.UseAuthorization();
 


### PR DESCRIPTION
Se agrega middleware para personalizar los mensajes de eror 401, 403 y 500 para todos los ocurridos en el servidor.